### PR TITLE
Factor out common code that creates connection to target device

### DIFF
--- a/newtmgr/cli/common.go
+++ b/newtmgr/cli/common.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
+	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
+	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
+)
+
+func getTargetCmdRunner() (*protocol.CmdRunner, error) {
+	cpm, err := config.NewConnProfileMgr()
+	if err != nil {
+		return nil, err
+	}
+
+	profile, err := cpm.GetConnProfile(ConnProfileName)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := transport.NewConn(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	runner, err := protocol.NewCmdRunner(conn)
+	if err != nil {
+		return nil, err
+	}
+	return runner, nil
+}

--- a/newtmgr/cli/config.go
+++ b/newtmgr/cli/config.go
@@ -3,9 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/util"
 	"github.com/spf13/cobra"
 )
@@ -14,22 +12,8 @@ func configRunCmd(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
 		nmUsage(cmd, util.NewNewtError("Need variable name"))
 	}
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
 
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/echo.go
+++ b/newtmgr/cli/echo.go
@@ -3,29 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"github.com/spf13/cobra"
 )
 
 func echoRunCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -6,30 +6,13 @@ import (
 	"io/ioutil"
 	"os"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/util"
 	"github.com/spf13/cobra"
 )
 
 func imageListCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -73,22 +56,7 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, util.NewNewtError(err.Error()))
 	}
 
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -143,22 +111,7 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 }
 
 func imageBootCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -212,22 +165,7 @@ func fileUploadCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, util.NewNewtError("Target filename too long"))
 	}
 
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -300,22 +238,7 @@ func fileDownloadCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, util.NewNewtError("Target filename too long"))
 	}
 
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/logs.go
+++ b/newtmgr/cli/logs.go
@@ -3,29 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"github.com/spf13/cobra"
 )
 
 func logsShowCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}
@@ -59,22 +42,7 @@ func logsShowCmd(cmd *cobra.Command, args []string) {
 }
 
 func logsClearCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/mpstats.go
+++ b/newtmgr/cli/mpstats.go
@@ -3,29 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"github.com/spf13/cobra"
 )
 
 func mempoolStatsRunCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/stats.go
+++ b/newtmgr/cli/stats.go
@@ -3,29 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"github.com/spf13/cobra"
 )
 
 func statsRunCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}

--- a/newtmgr/cli/taskstats.go
+++ b/newtmgr/cli/taskstats.go
@@ -3,29 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/config"
 	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/protocol"
-	"git-wip-us.apache.org/repos/asf/incubator-mynewt-newt/newtmgr/transport"
 	"github.com/spf13/cobra"
 )
 
 func taskStatsRunCmd(cmd *cobra.Command, args []string) {
-	cpm, err := config.NewConnProfileMgr()
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	profile, err := cpm.GetConnProfile(ConnProfileName)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	conn, err := transport.NewConn(profile)
-	if err != nil {
-		nmUsage(cmd, err)
-	}
-
-	runner, err := protocol.NewCmdRunner(conn)
+	runner, err := getTargetCmdRunner()
 	if err != nil {
 		nmUsage(cmd, err)
 	}


### PR DESCRIPTION
Create getTargetCmdRunner() function that refactors out common code
used by each command to establish a connection to the target device.