### PR TITLE
Partial core

### DIFF
--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -46,7 +46,7 @@ func imageListCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, err)
 	}
 
-	conn, err := transport.NewConnWithTimeout(profile, time.Second * 3)
+	conn, err := transport.NewConnWithTimeout(profile, time.Second*3)
 	if err != nil {
 		nmUsage(nil, err)
 	}
@@ -140,7 +140,7 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, err)
 	}
 
-	conn, err := transport.NewConnWithTimeout(profile, time.Second * 16)
+	conn, err := transport.NewConnWithTimeout(profile, time.Second*16)
 	if err != nil {
 		nmUsage(nil, err)
 	}
@@ -190,7 +190,7 @@ func imageUploadCmd(cmd *cobra.Command, args []string) {
 
 			rsp, err = runner.ReadResp()
 			if err == nil {
-				break;
+				break
 			}
 
 			/*

--- a/newtmgr/cli/usage.go
+++ b/newtmgr/cli/usage.go
@@ -23,16 +23,12 @@ import (
 	"fmt"
 	"os"
 
-	"mynewt.apache.org/newt/util"
-
 	"github.com/spf13/cobra"
 )
 
 func nmUsage(cmd *cobra.Command, err error) {
 	if err != nil {
-		sErr := err.(*util.NewtError)
 		fmt.Printf("ERROR: %s\n", err.Error())
-		fmt.Fprintf(os.Stderr, "[DEBUG] %s", sErr.StackTrace)
 	}
 
 	if cmd != nil {


### PR DESCRIPTION
Provide a way to capture part of a core by setting the offset and number of bytes to download.

Use a flag to control whether an elf file is created.