### PR TITLE
Better handling of Windows paths

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -321,6 +321,9 @@ func (b *Builder) link(elfName string, linkerScripts []string,
 
 	for _, bpkg := range b.PkgMap {
 		archiveNames, _ := filepath.Glob(b.PkgBinDir(bpkg) + "/*.a")
+		for i, archiveName := range archiveNames {
+			archiveNames[i] = filepath.ToSlash(archiveName)
+		}
 		pkgNames = append(pkgNames, archiveNames...)
 	}
 

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -77,6 +78,7 @@ func checkout(repoDir string, commit string) error {
 		return util.NewNewtError(fmt.Sprintf("Can't find git binary: %s\n",
 			err.Error()))
 	}
+	gitPath = filepath.ToSlash(gitPath)
 
 	if err := os.Chdir(repoDir); err != nil {
 		return util.NewNewtError(err.Error())
@@ -184,6 +186,7 @@ func (gd *GithubDownloader) DownloadRepo(commit string) (string, error) {
 		return "", util.NewNewtError(fmt.Sprintf("Can't find git binary: %s\n",
 			err.Error()))
 	}
+	gitPath = filepath.ToSlash(gitPath)
 
 	// Clone the repository.
 	cmd := []string{

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -88,7 +88,7 @@ func NewLocalPackage(r *repo.Repo, pkgDir string) *LocalPackage {
 		PkgV:             viper.New(),
 		SyscfgV:          viper.New(),
 		repo:             r,
-		basePath:         filepath.Clean(pkgDir) + "/", // XXX: Remove slash.
+		basePath:         filepath.ToSlash(filepath.Clean(pkgDir)),
 		deps:             map[string]*Dependency{},
 		injectedSettings: map[string]string{},
 	}
@@ -109,7 +109,7 @@ func (pkg *LocalPackage) FullName() string {
 }
 
 func (pkg *LocalPackage) BasePath() string {
-	return filepath.Clean(pkg.basePath)
+	return pkg.basePath
 }
 
 func (pkg *LocalPackage) RelativePath() string {
@@ -136,7 +136,7 @@ func (pkg *LocalPackage) SetName(name string) {
 }
 
 func (pkg *LocalPackage) SetBasePath(basePath string) {
-	pkg.basePath = basePath
+	pkg.basePath = filepath.ToSlash(filepath.Clean(basePath))
 }
 
 func (pkg *LocalPackage) SetType(packageType interfaces.PackageType) {
@@ -339,7 +339,7 @@ func (pkg *LocalPackage) Load() error {
 	if err != nil {
 		return err
 	}
-	pkg.AddCfgFilename(pkg.basePath + PACKAGE_FILE_NAME)
+	pkg.AddCfgFilename(pkg.basePath + "/" + PACKAGE_FILE_NAME)
 
 	// Set package name from the package
 	pkg.name = pkg.PkgV.GetString("pkg.name")
@@ -369,7 +369,7 @@ func (pkg *LocalPackage) Load() error {
 		if err != nil {
 			return err
 		}
-		pkg.AddCfgFilename(pkg.basePath + SYSCFG_YAML_FILENAME)
+		pkg.AddCfgFilename(pkg.basePath + "/" + SYSCFG_YAML_FILENAME)
 	}
 
 	return nil

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -481,7 +482,7 @@ func (proj *Project) loadConfig() error {
 }
 
 func (proj *Project) Init(dir string) error {
-	proj.BasePath = dir
+	proj.BasePath = filepath.ToSlash(filepath.Clean(dir))
 
 	// Only one project per system, when created, set it as the global project
 	interfaces.SetProject(proj)

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -623,9 +623,9 @@ func (r *Repo) Init(repoName string, rversreq string, d downloader.Downloader) e
 	path := interfaces.GetProject().Path()
 
 	if r.local {
-		r.localPath = filepath.Clean(path)
+		r.localPath = filepath.ToSlash(filepath.Clean(path))
 	} else {
-		r.localPath = filepath.Clean(path + "/" + REPOS_DIR + "/" + r.name)
+		r.localPath = filepath.ToSlash(filepath.Clean(path + "/" + REPOS_DIR + "/" + r.name))
 		r.minCommit = newtutil.RepoMinCommits[repoName]
 
 		upToDate, err := r.HasMinCommit()

--- a/newt/vendor/mynewt.apache.org/newt/util/util.go
+++ b/newt/vendor/mynewt.apache.org/newt/util/util.go
@@ -310,7 +310,12 @@ func ShellCommandLimitDbgOutput(
 	}
 
 	if err != nil {
-		return o, NewNewtError(string(o))
+		log.Debugf("err=%s", err.Error())
+		if len(o) > 0 {
+			return o, NewNewtError(string(o))
+		} else {
+			return o, NewNewtError(err.Error())
+		}
 	} else {
 		return o, nil
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -310,7 +310,12 @@ func ShellCommandLimitDbgOutput(
 	}
 
 	if err != nil {
-		return o, NewNewtError(string(o))
+		log.Debugf("err=%s", err.Error())
+		if len(o) > 0 {
+			return o, NewNewtError(string(o))
+		} else {
+			return o, NewNewtError(err.Error())
+		}
 	} else {
 		return o, nil
 	}


### PR DESCRIPTION
Go tries to be smart in how it handles paths, and uses a platform-appropriate separator (backslash on Windows).

However, many Windows tool ports don't deal with backslashes in paths very well, and in some cases like `cygwin` or `msys`, backslash is actually the wrong separator. On the other hand, Windows has natively supported slash-separated paths for a while now, and all tools handle those correctly.

This change normalizes paths used by `newt` a little bit; trying to consistently use slashes for separators (which a lot of code is doing via concatenation anyway), and removing trailing slashes from directories. With this change, `newt` runs quite well on Windows.