### PR TITLE
Fix load and debug options due to duplicated '-j' short option

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -408,7 +408,7 @@ func AddBuildCommands(cmd *cobra.Command) {
 	cmd.AddCommand(loadCmd)
 	AddTabCompleteFn(loadCmd, targetList)
 
-	loadCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "j", "",
+	loadCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "", "",
 		"extra commands to send to JTAG software")
 
 	debugHelpText := "Open debugger session for <target-name>."
@@ -420,7 +420,7 @@ func AddBuildCommands(cmd *cobra.Command) {
 		Run:   debugRunCmd,
 	}
 
-	debugCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "j",
+	debugCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "",
 		"", "extra commands to send to JTAG software")
 	debugCmd.PersistentFlags().BoolVarP(&noGDB_flag, "noGDB", "n", false,
 		"don't start GDB from command line")


### PR DESCRIPTION
Those two commands also provide short '-j' option for --extrajtagcmd
which is conflicting with '-j' short option for --jobs. Since those
are extra parameters just expect user to use long option for those.