### PR TITLE
Fixes MYNEWT-556

### DIFF
--- a/newt/pkg/package.go
+++ b/newt/pkg/package.go
@@ -30,28 +30,29 @@ const (
 	PACKAGE_STABILITY_DEV    = "dev"
 )
 
+// Define constants with values of increasing priority.
 const (
-	PACKAGE_TYPE_APP interfaces.PackageType = iota
-	PACKAGE_TYPE_BSP
-	PACKAGE_TYPE_SDK
-	PACKAGE_TYPE_COMPILER
-	PACKAGE_TYPE_LIB
-	PACKAGE_TYPE_TARGET
-	PACKAGE_TYPE_UNITTEST
-	PACKAGE_TYPE_GENERATED
+	PACKAGE_TYPE_COMPILER interfaces.PackageType = iota
 	PACKAGE_TYPE_MFG
+	PACKAGE_TYPE_SDK
+	PACKAGE_TYPE_GENERATED
+	PACKAGE_TYPE_LIB
+	PACKAGE_TYPE_BSP
+	PACKAGE_TYPE_UNITTEST
+	PACKAGE_TYPE_APP
+	PACKAGE_TYPE_TARGET
 )
 
 var PackageTypeNames = map[interfaces.PackageType]string{
-	PACKAGE_TYPE_APP:       "app",
-	PACKAGE_TYPE_BSP:       "bsp",
-	PACKAGE_TYPE_SDK:       "sdk",
 	PACKAGE_TYPE_COMPILER:  "compiler",
-	PACKAGE_TYPE_LIB:       "lib",
-	PACKAGE_TYPE_TARGET:    "target",
-	PACKAGE_TYPE_UNITTEST:  "unittest",
-	PACKAGE_TYPE_GENERATED: "generated",
 	PACKAGE_TYPE_MFG:       "mfg",
+	PACKAGE_TYPE_SDK:       "sdk",
+	PACKAGE_TYPE_GENERATED: "generated",
+	PACKAGE_TYPE_LIB:       "lib",
+	PACKAGE_TYPE_BSP:       "bsp",
+	PACKAGE_TYPE_UNITTEST:  "unittest",
+	PACKAGE_TYPE_APP:       "app",
+	PACKAGE_TYPE_TARGET:    "target",
 }
 
 // An interface, representing information about a Package


### PR DESCRIPTION
MYNEWT-556 Supports detection of Priority Violation
3 factors contributed to newt ignoring the override silenty.
1) The code only checked for Lateral override
2) The code processed syscfg.defs and syscfg.vals by package priority
   (lowest first) So when a package overrides the setting of higher
   priority the setting definition has not been processed yet, and was treated as
   overriding an undefined setting, which is treated as a warning.
3) newt build did not print out warning message for overriding an undefined setting (See MYNEWT-557)

Fix involves:
1) Process  all the syscfg.defs for all package first. Then process the syscfg.vals for each package.
2) Save the package that defined the setting in CfgEntry
3) Create CfgPriority to save priority violation: setting name, package that defined the setting,
   and package that override the setting.
4) Reordered PackageType definition by package priority (in increasing order of priority). Also reoreded
   PackageTypeNames to match order of PackageType definition (not functionally needed)
5) Compare priority types between the package overriding the value and the package defining the setting to detect prioirty violations. Newt aborts the build.