### PR TITLE
Fixes MYNEWT-575: Checks for required "value" field in a setting definition. 

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -283,9 +283,18 @@ func readSetting(name string, lpkg *pkg.LocalPackage,
 	entry := CfgEntry{}
 
 	entry.Name = name
-	entry.Description = stringValue(vals["description"])
-	entry.Value = stringValue(vals["value"])
 	entry.PackageDef = lpkg
+	entry.Description = stringValue(vals["description"])
+
+	// The value field for setting definition is required.
+	value_val, value_exist := vals["value"]
+	if value_exist {
+		entry.Value = stringValue(value_val)
+	} else {
+		return entry, util.FmtNewtError(
+			"setting %s does not have required value field", name)
+	}
+
 	if vals["type"] == nil {
 		entry.SettingType = CFG_SETTING_TYPE_RAW
 	} else {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -287,9 +287,9 @@ func readSetting(name string, lpkg *pkg.LocalPackage,
 	entry.Description = stringValue(vals["description"])
 
 	// The value field for setting definition is required.
-	value_val, value_exist := vals["value"]
-	if value_exist {
-		entry.Value = stringValue(value_val)
+	valueVal, valueExist := vals["value"]
+	if valueExist {
+		entry.Value = stringValue(valueVal)
 	} else {
 		return entry, util.FmtNewtError(
 			"setting %s does not have required value field", name)


### PR DESCRIPTION
Updated newt to check that a setting definition has the required "value" field:
1) Checks the "value" key is specified for a setting definition map.
2) Prints an error message and aborts when one is not specified.