### PR TITLE
MYNEWT-557 Warning override of undefined settings

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -188,6 +188,13 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 		return util.NewNewtError(errText)
 	}
 
+	warningText := strings.TrimSpace(t.res.WarningText())
+	if warningText != "" {
+		for _, line := range strings.Split(warningText, "\n") {
+			log.Warn(line)
+		}
+	}
+
 	if err := syscfg.EnsureWritten(t.res.Cfg,
 		GeneratedIncludeDir(t.target.Name())); err != nil {
 

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -191,7 +191,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 	warningText := strings.TrimSpace(t.res.WarningText())
 	if warningText != "" {
 		for _, line := range strings.Split(warningText, "\n") {
-			log.Warn(line)
+			log.Debugf(line)
 		}
 	}
 


### PR DESCRIPTION
Added support to newt build command to print out warning message for override of undefined settings.