### PR TITLE
Updates to newt help text, changed pkg clone to copy, removed features from vals, removed complete command

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -390,7 +390,7 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool) {
 func AddBuildCommands(cmd *cobra.Command) {
 	buildCmd := &cobra.Command{
 		Use:   "build <target-name> [target-names...]",
-		Short: "Builds one or more targets.",
+		Short: "Build one or more targets",
 		Run:   buildRunCmd,
 	}
 
@@ -401,7 +401,7 @@ func AddBuildCommands(cmd *cobra.Command) {
 
 	cleanCmd := &cobra.Command{
 		Use:   "clean <target-name> [target-names...] | all",
-		Short: "Deletes build artifacts for one or more targets.",
+		Short: "Delete build artifacts for one or more targets",
 		Run:   cleanRunCmd,
 	}
 
@@ -424,7 +424,7 @@ func AddBuildCommands(cmd *cobra.Command) {
 		return append(testablePkgList(), "all", "allexcept")
 	})
 
-	loadHelpText := "Load app image to target for <target-name>."
+	loadHelpText := "Load application image on to the board for <target-name>"
 
 	loadCmd := &cobra.Command{
 		Use:   "load <target-name>",
@@ -437,9 +437,9 @@ func AddBuildCommands(cmd *cobra.Command) {
 	AddTabCompleteFn(loadCmd, targetList)
 
 	loadCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "", "",
-		"extra commands to send to JTAG software")
+		"Extra commands to send to JTAG software")
 
-	debugHelpText := "Open debugger session for <target-name>."
+	debugHelpText := "Open a debugger session for <target-name>"
 
 	debugCmd := &cobra.Command{
 		Use:   "debug <target-name>",
@@ -449,9 +449,9 @@ func AddBuildCommands(cmd *cobra.Command) {
 	}
 
 	debugCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "",
-		"", "extra commands to send to JTAG software")
+		"", "Extra commands to send to JTAG software")
 	debugCmd.PersistentFlags().BoolVarP(&noGDB_flag, "noGDB", "n", false,
-		"don't start GDB from command line")
+		"Do not start GDB from command line")
 
 	cmd.AddCommand(debugCmd)
 	AddTabCompleteFn(debugCmd, targetList)

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -69,16 +69,16 @@ func createImageRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func AddImageCommands(cmd *cobra.Command) {
-	createImageHelpText := "Create image by adding image header to created " +
-		"binary file for <target-name>. Version number in the header is set " +
-		"to be <version>.\n\nTo sign the image give private key as <signing_key>."
-	createImageHelpEx := "  newt create-image <target-name> <version>\n"
-	createImageHelpEx += "  newt create-image my_target1 1.2.0\n"
+	createImageHelpText := "Create an image by adding an image header to the " +
+		"binary file created for <target-name>. Version number in the header is set " +
+		"to be <version>.\n\nTo sign the image give private key as <signing-key> and an optional key-id."
+	createImageHelpEx := "  newt create-image my_target1 1.2.0\n"
 	createImageHelpEx += "  newt create-image my_target1 1.2.0.3\n"
 	createImageHelpEx += "  newt create-image my_target1 1.2.0.3 private.pem\n"
+	createImageHelpEx += "  newt create-image my_target1 1.2.0.3 private.pem 5\n"
 
 	createImageCmd := &cobra.Command{
-		Use:     "create-image",
+		Use:     "create-image <target-name> <version> [signing-key [key-id]]",
 		Short:   "Add image header to target binary",
 		Long:    createImageHelpText,
 		Example: createImageHelpEx,

--- a/newt/cli/mfg_cmds.go
+++ b/newt/cli/mfg_cmds.go
@@ -193,7 +193,7 @@ func AddMfgCommands(cmd *cobra.Command) {
 
 	mfgDeployCmd := &cobra.Command{
 		Use:   "deploy <mfg-package-name> [version #.#.#.#]",
-		Short: "Builds and uploads a manufacturing image (create + load)",
+		Short: "Build and upload a manufacturing image (create + load)",
 		Run:   mfgDeployRunCmd,
 	}
 	mfgCmd.AddCommand(mfgDeployCmd)

--- a/newt/cli/pkg_cmds.go
+++ b/newt/cli/pkg_cmds.go
@@ -59,7 +59,7 @@ func pkgNewCmd(cmd *cobra.Command, args []string) {
 
 type dirOperation func(string, string) error
 
-func pkgCloneCmd(cmd *cobra.Command, args []string) {
+func pkgCopyCmd(cmd *cobra.Command, args []string) {
 	pkgCloneOrMoveCmd(cmd, args, util.CopyDir, "Cloning")
 }
 
@@ -243,25 +243,25 @@ func AddPackageCommands(cmd *cobra.Command) {
 	}
 
 	newCmd.PersistentFlags().StringVarP(&NewTypeStr, "type", "t",
-		"pkg", "Type of package to create: pkg, bsp, sdk.  Default pkg.")
+		"pkg", "Type of package to create: pkg, bsp, sdk.")
 
 	pkgCmd.AddCommand(newCmd)
 
-	cloneCmdHelpText := ""
-	cloneCmdHelpEx := ""
+	copyCmdHelpText := "Create a new package <dst-pkg> by cloning <src-pkg>"
+	copyCmdHelpEx := "  newt pkg copy apps/blinky apps/myapp"
 
-	cloneCmd := &cobra.Command{
-		Use:     "clone <srcpkg> <dstpkg>",
-		Short:   "Clone an existing package into another",
-		Long:    cloneCmdHelpText,
-		Example: cloneCmdHelpEx,
-		Run:     pkgCloneCmd,
+	copyCmd := &cobra.Command{
+		Use:     "copy <src-pkg> <dst-pkg>",
+		Short:   "Copy an existing package into another",
+		Long:    copyCmdHelpText,
+		Example: copyCmdHelpEx,
+		Run:     pkgCopyCmd,
 	}
 
-	pkgCmd.AddCommand(cloneCmd)
+	pkgCmd.AddCommand(copyCmd)
 
 	moveCmdHelpText := ""
-	moveCmdHelpEx := ""
+	moveCmdHelpEx := "  newt pkg move apps/blinky apps/myapp"
 
 	moveCmd := &cobra.Command{
 		Use:     "move <oldpkg> <newpkg>",

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -99,9 +99,9 @@ func AddRunCommands(cmd *cobra.Command) {
 	}
 
 	runCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "", "",
-		"extra commands to send to JTAG software")
+		"Extra commands to send to JTAG software")
 	runCmd.PersistentFlags().BoolVarP(&noGDB_flag, "noGDB", "n", false,
-		"don't start GDB from command line")
+		"Do not start GDB from command line")
 
 	cmd.AddCommand(runCmd)
 	AddTabCompleteFn(runCmd, func() []string {

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -696,7 +696,7 @@ func AddTargetCommands(cmd *cobra.Command) {
 	targetHelpEx := ""
 	targetCmd := &cobra.Command{
 		Use:     "target",
-		Short:   "Command for manipulating targets",
+		Short:   "Commands to create, delete, configure, and query targets",
 		Long:    targetHelpText,
 		Example: targetHelpEx,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -721,15 +721,19 @@ func AddTargetCommands(cmd *cobra.Command) {
 	targetCmd.AddCommand(showCmd)
 	AddTabCompleteFn(showCmd, targetList)
 
-	setHelpText := "Set a target variable (<var-name>) on target " +
-		"<target-name> to value <value>."
-	setHelpEx := "  newt target set <target-name> <var-name>=<value>\n"
-	setHelpEx += "  newt target set my_target1 var_name=value\n"
-	setHelpEx += "  newt target set my_target1 arch=cortex_m4\n"
-	setHelpEx += "  newt target set my_target1 var_name   (display valid values for <var_name>)"
+	setHelpText := "Set a target variable (<var-name>) on target "
+	setHelpText += "<target-name> to value <value>.\n\n"
+	setHelpText += "Warning: When setting the syscfg variable, a new syscfg.yml file\n"
+	setHelpText += "is created and the current settings are deleted. Only the settings\n"
+	setHelpText += "specified in the command are saved in the syscfg.yml file."
+	setHelpEx := "  newt target set my_target1 build_profile=optimized "
+	setHelpEx += "cflags=\"-DNDEBUG\"\n"
+	setHelpEx += "  newt target set my_target1 "
+	setHelpEx += "syscfg=LOG_NEWTMGR=1:CONFIG_NEWTMGR=0\n"
 
 	setCmd := &cobra.Command{
-		Use:     "set",
+		Use: "set <target-name> <var-name>=<value>" +
+			"[:<var-name>=<value>...]",
 		Short:   "Set target configuration variable",
 		Long:    setHelpText,
 		Example: setHelpEx,
@@ -768,12 +772,11 @@ func AddTargetCommands(cmd *cobra.Command) {
 
 	targetCmd.AddCommand(delCmd)
 
-	copyHelpText := "Create a new target by cloning <src-target>."
-	copyHelpEx := "  newt target copy <src-target> <dst-target>\n"
-	copyHelpEx += "  newt target copy blinky_sim my_target"
+	copyHelpText := "Create a new target <dst-target> by cloning <src-target>"
+	copyHelpEx := "  newt target copy blinky_sim my_target"
 
 	copyCmd := &cobra.Command{
-		Use:     "copy",
+		Use:     "copy <src-target> <dst-target>",
 		Short:   "Copy target",
 		Long:    copyHelpText,
 		Example: copyHelpEx,
@@ -783,7 +786,7 @@ func AddTargetCommands(cmd *cobra.Command) {
 	targetCmd.AddCommand(copyCmd)
 	AddTabCompleteFn(copyCmd, targetList)
 
-	configHelpText := "View and modify a target's system configuration."
+	configHelpText := "View or populate a target's system configuration"
 
 	configCmd := &cobra.Command{
 		Use:   "config",
@@ -799,7 +802,7 @@ func AddTargetCommands(cmd *cobra.Command) {
 	configShowCmd := &cobra.Command{
 		Use:   "show <target>",
 		Short: "View a target's system configuration",
-		Long:  "View a target's system configuration.",
+		Long:  "View a target's system configuration",
 		Run:   targetConfigShowCmd,
 	}
 

--- a/newt/cli/vals_cmds.go
+++ b/newt/cli/vals_cmds.go
@@ -55,7 +55,7 @@ func valsRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func AddValsCommands(cmd *cobra.Command) {
-	valsShortHelp := "Displays valid values for the specified element type(s)"
+	valsShortHelp := "Display valid values for the specified element type(s)"
 
 	valsLongHelp := valsShortHelp + ".\n\nElement types:\n    " +
 		strings.Join(VarTypes(), "\n    ")

--- a/newt/cli/vars.go
+++ b/newt/cli/vars.go
@@ -130,9 +130,6 @@ var varsMap = map[string]func() ([]string, error){
 	"api": func() ([]string, error) {
 		return settingValues("pkg.apis")
 	},
-	"feature": func() ([]string, error) {
-		return settingValues("pkg.features")
-	},
 
 	// Target settings.
 	"build_profile": func() ([]string, error) {

--- a/newt/newt.go
+++ b/newt/newt.go
@@ -38,6 +38,7 @@ var newtQuiet bool
 var newtVerbose bool
 var newtLogFile string
 var newtNumJobs int
+var newtHelp bool
 
 func newtDfltNumJobs() int {
 	maxProcs := runtime.GOMAXPROCS(0)
@@ -115,12 +116,14 @@ func newtCmd() *cobra.Command {
 		"", "Filename to tee output to")
 	newtCmd.PersistentFlags().IntVarP(&newtNumJobs, "jobs", "j",
 		newtDfltNumJobs(), "Number of concurrent build jobs")
+	newtCmd.PersistentFlags().BoolVarP(&newtHelp, "help", "h",
+		false, "Help for newt commands")
 
-	versHelpText := cli.FormatHelp(`Display the Newt version number.`)
+	versHelpText := cli.FormatHelp(`Display the Newt version number`)
 	versHelpEx := "  newt version"
 	versCmd := &cobra.Command{
 		Use:     "version",
-		Short:   "Display the Newt version number.",
+		Short:   "Display the Newt version number",
 		Long:    versHelpText,
 		Example: versHelpEx,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -137,7 +140,6 @@ func main() {
 	cmd := newtCmd()
 
 	cli.AddBuildCommands(cmd)
-	cli.AddCompleteCommands(cmd)
 	cli.AddImageCommands(cmd)
 	cli.AddPackageCommands(cmd)
 	cli.AddProjectCommands(cmd)


### PR DESCRIPTION
1) Updated help text
2) Changed pkg clone to pkg copy (document has been updated)
3) Removed features from newt vals command.
4) Removed newt complete command.