### PR TITLE
Add back "newt complete" and remove from help text.

### DIFF
--- a/newt/cli/complete_cmd.go
+++ b/newt/cli/complete_cmd.go
@@ -237,17 +237,13 @@ func completeRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func AddCompleteCommands(cmd *cobra.Command) {
-	completeShortHelp := "Performs Bash Autocompletion (-C)"
-
-	completeLongHelp := completeShortHelp + ".\n\n" +
-		" this command reads environment variables COMP_LINE and COMP_POINT " +
-		" and will send completion options out stdout as one option per line  "
 
 	completeCmd := &cobra.Command{
-		Use:   "complete",
-		Short: completeShortHelp,
-		Long:  completeLongHelp,
-		Run:   completeRunCmd,
+		Use:    "complete",
+		Short:  "",
+		Long:   "",
+		Run:    completeRunCmd,
+		Hidden: true,
 	}
 
 	/* silence errors on the complete command because we have partial flags */

--- a/newt/newt.go
+++ b/newt/newt.go
@@ -140,6 +140,7 @@ func main() {
 	cmd := newtCmd()
 
 	cli.AddBuildCommands(cmd)
+	cli.AddCompleteCommands(cmd)
 	cli.AddImageCommands(cmd)
 	cli.AddPackageCommands(cmd)
 	cli.AddProjectCommands(cmd)


### PR DESCRIPTION
1) Added "newt complete" support back.
2) Make the command hidden so it is not in the list of "Available Commands" in newt help.
3) Removed "newt complete" help text.