### PR TITLE
Fix runtime exceptions for "newtmgr conn add/delete" and update help text for newtmgr 

### DIFF
--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -35,7 +35,7 @@ func Commands() *cobra.Command {
 	logLevelStr := ""
 	nmCmd := &cobra.Command{
 		Use:   "newtmgr",
-		Short: "Newtmgr helps you manage devices running the Mynewt OS",
+		Short: "Newtmgr helps you manage remote devices running the Mynewt OS",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			NewtmgrLogLevel, err := log.ParseLevel(logLevelStr)
 			err = util.Init(NewtmgrLogLevel, "", util.VERBOSITY_DEFAULT)

--- a/newtmgr/cli/commands.go
+++ b/newtmgr/cli/commands.go
@@ -29,12 +29,13 @@ import (
 
 var ConnProfileName string
 var NewtmgrLogLevel log.Level
+var NewtmgrHelp bool
 
 func Commands() *cobra.Command {
 	logLevelStr := ""
 	nmCmd := &cobra.Command{
 		Use:   "newtmgr",
-		Short: "Newtmgr helps you manage remote instances of the Mynewt OS.",
+		Short: "Newtmgr helps you manage devices running the Mynewt OS",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			NewtmgrLogLevel, err := log.ParseLevel(logLevelStr)
 			err = util.Init(NewtmgrLogLevel, "", util.VERBOSITY_DEFAULT)
@@ -48,13 +49,17 @@ func Commands() *cobra.Command {
 	}
 
 	nmCmd.PersistentFlags().StringVarP(&ConnProfileName, "conn", "c", "",
-		"connection profile to use.")
+		"connection profile to use")
 
 	nmCmd.PersistentFlags().StringVarP(&logLevelStr, "loglevel", "l", "info",
-		"log level to use (default INFO.)")
+		"log level to use")
 
 	nmCmd.PersistentFlags().BoolVarP(&nmutil.TraceLogEnabled, "trace", "t",
 		false, "print all bytes transmitted and received")
+
+	// Add the help flag so it shows up under Global Flags
+	nmCmd.PersistentFlags().BoolVarP(&NewtmgrHelp, "help", "h",
+		false, "Help for newtmgr commands")
 
 	nmCmd.AddCommand(configCmd())
 	nmCmd.AddCommand(connProfileCmd())

--- a/newtmgr/cli/config.go
+++ b/newtmgr/cli/config.go
@@ -72,9 +72,12 @@ func configRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func configCmd() *cobra.Command {
+	configCmdLongHelp := "Read or write a config value for <var-name> variable on " +
+		"a device.\nSpecify a var-value to write a value to a device.\n"
 	statsCmd := &cobra.Command{
-		Use:   "config",
-		Short: "Read or write config value on target",
+		Use:   "config <var-name> [var-value] -c <conn_profile>",
+		Short: "Read or write a config value on a device",
+		Long:  configCmdLongHelp,
 		Run:   configRunCmd,
 	}
 

--- a/newtmgr/cli/connprofile.go
+++ b/newtmgr/cli/connprofile.go
@@ -62,6 +62,11 @@ func connProfileAddCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, err)
 	}
 
+	// Connection Profile name required
+	if len(args) == 0 {
+		nmUsage(cmd, util.NewNewtError("Need connection profile name"))
+	}
+
 	name := args[0]
 	cp, err := config.NewConnProfile(name)
 	if err != nil {
@@ -161,6 +166,11 @@ func connProfileDelCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, err)
 	}
 
+	// Connection Profile name required
+	if len(args) == 0 {
+		nmUsage(cmd, util.NewNewtError("Need connection profile name"))
+	}
+
 	name := args[0]
 
 	if err := cpm.DeleteConnProfile(name); err != nil {
@@ -180,14 +190,14 @@ func connProfileCmd() *cobra.Command {
 	}
 
 	addCmd := &cobra.Command{
-		Use:   "add",
+		Use:   "add <conn_profile> [varname=value ...] ",
 		Short: "Add a newtmgr connection profile",
 		Run:   connProfileAddCmd,
 	}
 	cpCmd.AddCommand(addCmd)
 
 	deleCmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete <conn_profile>",
 		Short: "Delete a newtmgr connection profile",
 		Run:   connProfileDelCmd,
 	}

--- a/newtmgr/cli/crash.go
+++ b/newtmgr/cli/crash.go
@@ -87,8 +87,8 @@ func crashCmd() *cobra.Command {
 	crashEx := "   newtmgr -c olimex crash div0\n"
 
 	crashCmd := &cobra.Command{
-		Use:     "crash [div0|jump0|ref0|assert|wdog]",
-		Short:   "Send crash command to remote endpoint using newtmgr",
+		Use:     "crash [div0|jump0|ref0|assert|wdog] -c <conn_profile>",
+		Short:   "Send crash command to a device",
 		Example: crashEx,
 		Run:     crashRunCmd,
 	}

--- a/newtmgr/cli/datetime.go
+++ b/newtmgr/cli/datetime.go
@@ -86,8 +86,8 @@ func dateTimeCmd(cmd *cobra.Command, args []string) {
 
 func dTimeCmd() *cobra.Command {
 	dateTCmd := &cobra.Command{
-		Use:   "datetime",
-		Short: "Manage datetime on the device",
+		Use:   "datetime -c <conn_profile>",
+		Short: "Manage datetime on a device",
 		Run:   dateTimeCmd,
 	}
 

--- a/newtmgr/cli/echo.go
+++ b/newtmgr/cli/echo.go
@@ -67,8 +67,8 @@ func echoRunCmd(cmd *cobra.Command, args []string) {
 
 func echoCmd() *cobra.Command {
 	echoCmd := &cobra.Command{
-		Use:   "echo",
-		Short: "Send data to remote endpoint using newtmgr, and receive data back",
+		Use:   "echo <text> -c <conn_profile>",
+		Short: "Send data to a device and display the echoed back data",
 		Run:   echoRunCmd,
 	}
 

--- a/newtmgr/cli/fs.go
+++ b/newtmgr/cli/fs.go
@@ -186,7 +186,7 @@ func fsDownloadCmd(cmd *cobra.Command, args []string) {
 func fsCmd() *cobra.Command {
 	fsCmd := &cobra.Command{
 		Use:   "fs",
-		Short: "Access files on device",
+		Short: "Access files on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -195,8 +195,8 @@ func fsCmd() *cobra.Command {
 	uploadEx := "  newtmgr -c olimex fs upload sample.lua /sample.lua\n"
 
 	uploadCmd := &cobra.Command{
-		Use:     "upload <src-filename> <dst-filename>",
-		Short:   "Upload file to target",
+		Use:     "upload <src-filename> <dst-filename> -c <conn_profile>",
+		Short:   "Upload file to a device",
 		Example: uploadEx,
 		Run:     fsUploadCmd,
 	}
@@ -205,8 +205,8 @@ func fsCmd() *cobra.Command {
 	downloadEx := "  newtmgr -c olimex image download /cfg/mfg mfg.txt\n"
 
 	downloadCmd := &cobra.Command{
-		Use:     "download <src-filename> <dst-filename>",
-		Short:   "Download file from target",
+		Use:     "download <src-filename> <dst-filename> -c <conn_profile>",
+		Short:   "Download file from a device",
 		Example: downloadEx,
 		Run:     fsDownloadCmd,
 	}

--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -524,7 +524,7 @@ func coreEraseCmd(cmd *cobra.Command, args []string) {
 func imageCmd() *cobra.Command {
 	imageCmd := &cobra.Command{
 		Use:   "image",
-		Short: "Manage images on remote instance",
+		Short: "Manage images on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -532,7 +532,7 @@ func imageCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "Show target images",
+		Short: "Show images on a device",
 		Run:   imageStateListCmd,
 	}
 	imageCmd.AddCommand(listCmd)
@@ -545,7 +545,7 @@ func imageCmd() *cobra.Command {
 	imageCmd.AddCommand(testCmd)
 
 	confirmCmd := &cobra.Command{
-		Use:   "confirm [hex-image-hash]",
+		Use:   "confirm [hex-image-hash] -c <conn_profile>",
 		Short: "Permanently run image",
 		Long: "If a hash is specified, permanently switch to the " +
 			"corresponding image.  If no hash is specified, the current " +
@@ -554,12 +554,11 @@ func imageCmd() *cobra.Command {
 	}
 	imageCmd.AddCommand(confirmCmd)
 
-	uploadEx := "  newtmgr -c olimex image upload <image_file\n"
-	uploadEx += "  newtmgr -c olimex image upload bin/slinky_zero/apps/slinky.img\n"
+	uploadEx := "  newtmgr -c olimex image upload bin/slinky_zero/apps/slinky.img\n"
 
 	uploadCmd := &cobra.Command{
-		Use:     "upload",
-		Short:   "Upload image to target",
+		Use:     "upload <image-file> -c <conn_profile>",
+		Short:   "Upload image to a device",
 		Example: uploadEx,
 		Run:     imageUploadCmd,
 	}
@@ -568,20 +567,19 @@ func imageCmd() *cobra.Command {
 	coreListEx := "  newtmgr -c olimex image corelist\n"
 
 	coreListCmd := &cobra.Command{
-		Use:     "corelist",
-		Short:   "List core(s) on target",
+		Use:     "corelist -c <conn_profile>",
+		Short:   "List core(s) on a device",
 		Example: coreListEx,
 		Run:     coreListCmd,
 	}
 	imageCmd.AddCommand(coreListCmd)
 
-	coreEx := "  newtmgr -c olimex image coredownload -e <filename>\n"
-	coreEx += "  newtmgr -c olimex image coredownload -e core\n"
+	coreEx := "  newtmgr -c olimex image coredownload -e core\n"
 	coreEx += "  newtmgr -c olimex image coredownload --offset 10 -n 10 core\n"
 
 	coreDownloadCmd := &cobra.Command{
-		Use:     "coredownload",
-		Short:   "Download core from target",
+		Use:     "coredownload <core_filename> -c <conn_profile>",
+		Short:   "Download core from a device",
 		Example: coreEx,
 		Run:     coreDownloadCmd,
 	}
@@ -600,8 +598,8 @@ func imageCmd() *cobra.Command {
 	coreEraseEx := "  newtmgr -c olimex image coreerase\n"
 
 	coreEraseCmd := &cobra.Command{
-		Use:     "coreerase",
-		Short:   "Erase core on target",
+		Use:     "coreerase -c <conn_profile>",
+		Short:   "Erase core on a device",
 		Example: coreEraseEx,
 		Run:     coreEraseCmd,
 	}

--- a/newtmgr/cli/logs.go
+++ b/newtmgr/cli/logs.go
@@ -327,44 +327,44 @@ func logsClearCmd(cmd *cobra.Command, args []string) {
 func logsCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "log",
-		Short: "Handles logs on remote instance",
+		Short: "Handle logs on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
 	}
 
 	showCmd := &cobra.Command{
-		Use:   "show [log-name] [min-index] [min-timestamp]",
-		Short: "Show logs on target",
+		Use:   "show [log-name] [min-index] [min-timestamp] -c <conn_profile>",
+		Short: "Show the logs on a device",
 		Run:   logsShowCmd,
 	}
 	logsCmd.AddCommand(showCmd)
 
 	clearCmd := &cobra.Command{
-		Use:   "clear",
-		Short: "Clear logs on target",
+		Use:   "clear -c <conn_profile>",
+		Short: "Clear the logs on a device",
 		Run:   logsClearCmd,
 	}
 	logsCmd.AddCommand(clearCmd)
 
 	moduleListCmd := &cobra.Command{
-		Use:   "module_list",
-		Short: "Module List Command",
+		Use:   "module_list -c <conn_profile>",
+		Short: "Show the log module names",
 		Run:   logsModuleListCmd,
 	}
 	logsCmd.AddCommand(moduleListCmd)
 
 	levelListCmd := &cobra.Command{
-		Use:   "level_list",
-		Short: "Level List Command",
+		Use:   "level_list -c <conn_profile>",
+		Short: "Show the log levels",
 		Run:   logsLevelListCmd,
 	}
 
 	logsCmd.AddCommand(levelListCmd)
 
 	ListCmd := &cobra.Command{
-		Use:   "list",
-		Short: "Log List Command",
+		Use:   "list -c <conn_profile>",
+		Short: "Show the log names",
 		Run:   logsListCmd,
 	}
 

--- a/newtmgr/cli/mpstats.go
+++ b/newtmgr/cli/mpstats.go
@@ -74,8 +74,8 @@ func mempoolStatsRunCmd(cmd *cobra.Command, args []string) {
 
 func mempoolStatsCmd() *cobra.Command {
 	mempoolStatsCmd := &cobra.Command{
-		Use:   "mpstats",
-		Short: "Read statistics from a remote endpoint",
+		Use:   "mpstats -c <conn_profile>",
+		Short: "Read memory pool statistics from a device",
 		Run:   mempoolStatsRunCmd,
 	}
 

--- a/newtmgr/cli/reset.go
+++ b/newtmgr/cli/reset.go
@@ -57,8 +57,8 @@ func resetRunCmd(cmd *cobra.Command, args []string) {
 
 func resetCmd() *cobra.Command {
 	resetCmd := &cobra.Command{
-		Use:   "reset",
-		Short: "Send reset request to remote endpoint using newtmgr",
+		Use:   "reset -c <conn_profile>",
+		Short: "Send reset request to a device",
 		Run:   resetRunCmd,
 	}
 

--- a/newtmgr/cli/runtest.go
+++ b/newtmgr/cli/runtest.go
@@ -28,118 +28,118 @@ import (
 
 func runCmd() *cobra.Command {
 	runCmd := &cobra.Command{
-		Use:     "run",
-		Short:   "Run procedures on remote device",
+		Use:   "run",
+		Short: "Run procedures on a device",
 		Run: func(cmd *cobra.Command, args []string) {
-                cmd.HelpFunc()(cmd, args)
-        },
+			cmd.HelpFunc()(cmd, args)
+		},
 	}
 
-    runtestEx :="  newtmgr -c conn run test all 201612161220"
+	runtestEx := "  newtmgr -c conn run test all 201612161220"
 
 	runTestCmd := &cobra.Command{
-		Use:     "test [all | testname] [token]",
-        Short:   "Run commands on remote device - \"token\" output on log messages",
-        Example: runtestEx,
+		Use:     "test [all | testname] [token] -c <conn_profile>",
+		Short:   "Run commands a device - \"token\" output on log messages",
+		Example: runtestEx,
 		Run:     runTestCmd,
 	}
-    runCmd.AddCommand(runTestCmd)
+	runCmd.AddCommand(runTestCmd)
 
 	runListCmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List registered commands on remote device",
-		Run:     runListCmd,
+		Use:   "list -c <conn_profile>",
+		Short: "List registered commands on a device",
+		Run:   runListCmd,
 	}
-    runCmd.AddCommand(runListCmd)
+	runCmd.AddCommand(runListCmd)
 
 	return runCmd
 }
 
 func runTestCmd(cmd *cobra.Command, args []string) {
-    runner, err := getTargetCmdRunner()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
-    defer runner.Conn.Close()
+	runner, err := getTargetCmdRunner()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
+	defer runner.Conn.Close()
 
-    req, err := protocol.NewRunTestReq()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	req, err := protocol.NewRunTestReq()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    if len(args) > 0 {
-        req.Testname = args[0]
-        if len(args) > 1 {
-            req.Token = args[1]
-        } else {
-            req.Token = ""
-        }
-    } else {
-        /*
-         * If nothing specified, turn on "all" by default
-         * There is no default token.
-         */
-        req.Testname = "all"
-        req.Token = ""
-    }
+	if len(args) > 0 {
+		req.Testname = args[0]
+		if len(args) > 1 {
+			req.Token = args[1]
+		} else {
+			req.Token = ""
+		}
+	} else {
+		/*
+		 * If nothing specified, turn on "all" by default
+		 * There is no default token.
+		 */
+		req.Testname = "all"
+		req.Token = ""
+	}
 
-    nmr, err := req.Encode()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	nmr, err := req.Encode()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    if err := runner.WriteReq(nmr); err != nil {
-        nmUsage(cmd, err)
-    }
+	if err := runner.WriteReq(nmr); err != nil {
+		nmUsage(cmd, err)
+	}
 
-    rsp, err := runner.ReadResp()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	rsp, err := runner.ReadResp()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    decodedResponse, err := protocol.DecodeRunTestResponse(rsp.Data)
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	decodedResponse, err := protocol.DecodeRunTestResponse(rsp.Data)
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    if decodedResponse.ReturnCode != 0 {
-        fmt.Printf("Return Code = %d\n", decodedResponse.ReturnCode)
-    }
+	if decodedResponse.ReturnCode != 0 {
+		fmt.Printf("Return Code = %d\n", decodedResponse.ReturnCode)
+	}
 }
 
 func runListCmd(cmd *cobra.Command, args []string) {
-    runner, err := getTargetCmdRunner()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	runner, err := getTargetCmdRunner()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    defer runner.Conn.Close()
-    req, err := protocol.NewRunListReq()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	defer runner.Conn.Close()
+	req, err := protocol.NewRunListReq()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    nmr, err := req.Encode()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	nmr, err := req.Encode()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    if err := runner.WriteReq(nmr); err != nil {
-        nmUsage(cmd, err)
-    }
+	if err := runner.WriteReq(nmr); err != nil {
+		nmUsage(cmd, err)
+	}
 
-    rsp, err := runner.ReadResp()
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	rsp, err := runner.ReadResp()
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    decodedResponse, err := protocol.DecodeRunListResponse(rsp.Data)
-    if err != nil {
-        nmUsage(cmd, err)
-    }
+	decodedResponse, err := protocol.DecodeRunListResponse(rsp.Data)
+	if err != nil {
+		nmUsage(cmd, err)
+	}
 
-    fmt.Println(decodedResponse.List)
-    if decodedResponse.ReturnCode != 0 {
-        fmt.Printf("Return Code = %d\n", decodedResponse.ReturnCode)
-    }
+	fmt.Println(decodedResponse.List)
+	if decodedResponse.ReturnCode != 0 {
+		fmt.Printf("Return Code = %d\n", decodedResponse.ReturnCode)
+	}
 }

--- a/newtmgr/cli/stats.go
+++ b/newtmgr/cli/stats.go
@@ -111,14 +111,14 @@ func statsRunCmd(cmd *cobra.Command, args []string) {
 
 func statsCmd() *cobra.Command {
 	statsCmd := &cobra.Command{
-		Use:   "stat",
-		Short: "Read statistics from a remote endpoint",
+		Use:   "stat ",
+		Short: "Read statistics from a device",
 		Run:   statsRunCmd,
 	}
 
 	ListCmd := &cobra.Command{
-		Use:   "list",
-		Short: "Read list of statistics from a remote endpoint",
+		Use:   "list -c <conn_profile>",
+		Short: "Read list of statistics from a device",
 		Run:   statsListRunCmd,
 	}
 

--- a/newtmgr/cli/taskstats.go
+++ b/newtmgr/cli/taskstats.go
@@ -61,7 +61,7 @@ func taskStatsRunCmd(cmd *cobra.Command, args []string) {
 	if tsrsp.ReturnCode == 0 {
 		fmt.Printf("  %8s %3s %3s %8s %8s %8s %8s %8s %8s\n",
 			"task", "pri", "tid", "runtime", "csw", "stksz",
-			"stkuse", "last_checkin", "next_checkin");
+			"stkuse", "last_checkin", "next_checkin")
 		for k, info := range tsrsp.Tasks {
 			fmt.Printf("  %8s %3d %3d %8d %8d %8d %8d %8d %8d\n",
 				k,
@@ -79,8 +79,8 @@ func taskStatsRunCmd(cmd *cobra.Command, args []string) {
 
 func taskStatsCmd() *cobra.Command {
 	taskStatsCmd := &cobra.Command{
-		Use:   "taskstats",
-		Short: "Read statistics from a remote endpoint",
+		Use:   "taskstats -c <conn_profile>",
+		Short: "Read task statistics from a device",
 		Run:   taskStatsRunCmd,
 	}
 


### PR DESCRIPTION
1) Fixed runtime exception when no argument is given to the  `newtmgr conn add` and the `newtmgr conn delete` command. 
2) Updated help texts.