### PR TITLE
More newtmgr command tool help text updates.

### DIFF
--- a/newtmgr/cli/connprofile.go
+++ b/newtmgr/cli/connprofile.go
@@ -190,7 +190,7 @@ func connProfileCmd() *cobra.Command {
 	}
 
 	addCmd := &cobra.Command{
-		Use:   "add <conn_profile> [varname=value ...] ",
+		Use:   "add <conn_profile> <varname=value ...> ",
 		Short: "Add a newtmgr connection profile",
 		Run:   connProfileAddCmd,
 	}
@@ -203,9 +203,14 @@ func connProfileCmd() *cobra.Command {
 	}
 	cpCmd.AddCommand(deleCmd)
 
+	connShowHelpText := "Show information for the conn_profile connection "
+	connShowHelpText += "profile or for all\nconnection profiles "
+	connShowHelpText += "if conn_profile is not specified.\n"
+
 	showCmd := &cobra.Command{
-		Use:   "show",
+		Use:   "show [conn_profile]",
 		Short: "Show newtmgr connection profiles",
+		Long:  connShowHelpText,
 		Run:   connProfileShowCmd,
 	}
 	cpCmd.AddCommand(showCmd)

--- a/newtmgr/cli/crash.go
+++ b/newtmgr/cli/crash.go
@@ -87,8 +87,8 @@ func crashCmd() *cobra.Command {
 	crashEx := "   newtmgr -c olimex crash div0\n"
 
 	crashCmd := &cobra.Command{
-		Use:     "crash [div0|jump0|ref0|assert|wdog] -c <conn_profile>",
-		Short:   "Send crash command to a device",
+		Use:     "crash <div0|jump0|ref0|assert|wdog> -c <conn_profile>",
+		Short:   "Send a crash command to a device",
 		Example: crashEx,
 		Run:     crashRunCmd,
 	}

--- a/newtmgr/cli/datetime.go
+++ b/newtmgr/cli/datetime.go
@@ -61,14 +61,7 @@ func dateTimeCmd(cmd *cobra.Command, args []string) {
 		nmUsage(cmd, err)
 	}
 
-	err_str := "Command: datetime\n" +
-		"For writing datetime <argument>\n" +
-		"Need to specify a datetime in RFC 3339 format\n" +
-		"2016-03-02T22:44:00                  UTC time (implicit)\n" +
-		"2016-03-02T22:44:00Z                 UTC time (explicit)\n" +
-		"2016-03-02T22:44:00-08:00            PST timezone\n" +
-		"2016-03-02T22:44:00.1                fractional seconds\n" +
-		"2016-03-02T22:44:00.101+05:30        fractional seconds with timezone\n"
+	err_str := "Need to specify a datetime in RFC 3339 format\n"
 
 	if len(args) > 1 {
 		nmUsage(cmd, util.NewNewtError(err_str))
@@ -85,10 +78,29 @@ func dateTimeCmd(cmd *cobra.Command, args []string) {
 }
 
 func dTimeCmd() *cobra.Command {
+	dateTimeHelpText := "Display or set datetime on a device. "
+	dateTimeHelpText += "Specify a datetime-value\n"
+	dateTimeHelpText += "to set the datetime on the device.\n\n"
+	dateTimeHelpText += "Must specify datetime-value in RFC 3339 format.\n"
+
+	dateTimeEx := "newtmgr datetime -c myserial\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00 -c myserial"
+	dateTimeEx += "             (implicit UTC) \n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00Z -c myserial"
+	dateTimeEx += "            (explicit UTC)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00-08:00 -c myserial"
+	dateTimeEx += "       (PST)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.1 -c myserial"
+	dateTimeEx += "           (fractional secs)\n"
+	dateTimeEx += "newtmgr datetime 2016-03-02T22:44:00.101+05:30 -c myserial"
+	dateTimeEx += "   (fractional secs + timezone)\n"
+
 	dateTCmd := &cobra.Command{
-		Use:   "datetime -c <conn_profile>",
-		Short: "Manage datetime on a device",
-		Run:   dateTimeCmd,
+		Use:     "datetime [datetime-value] -c <conn_profile>",
+		Short:   "Manage datetime on a device",
+		Long:    dateTimeHelpText,
+		Example: dateTimeEx,
+		Run:     dateTimeCmd,
 	}
 
 	return dateTCmd

--- a/newtmgr/cli/image.go
+++ b/newtmgr/cli/image.go
@@ -578,19 +578,19 @@ func imageCmd() *cobra.Command {
 	coreEx += "  newtmgr -c olimex image coredownload --offset 10 -n 10 core\n"
 
 	coreDownloadCmd := &cobra.Command{
-		Use:     "coredownload <core_filename> -c <conn_profile>",
+		Use:     "coredownload <core-filename> -c <conn_profile>",
 		Short:   "Download core from a device",
 		Example: coreEx,
 		Run:     coreDownloadCmd,
 	}
-	coreDownloadCmd.Flags().BoolVarP(&coreElfify, "elfify", "e", false, "Creat an elf file")
+	coreDownloadCmd.Flags().BoolVarP(&coreElfify, "elfify", "e", false, "Create an ELF file")
 	coreDownloadCmd.Flags().Uint32Var(&coreOffset, "offset", 0, "Start offset")
 	coreDownloadCmd.Flags().Uint32VarP(&coreNumBytes, "bytes", "n", 0, "Number of bytes of the core to download")
 	imageCmd.AddCommand(coreDownloadCmd)
 
 	coreConvertCmd := &cobra.Command{
 		Use:   "coreconvert <core-filename> <elf-filename>",
-		Short: "Convert core to elf",
+		Short: "Convert core to ELF",
 		Run:   coreConvertCmd,
 	}
 	imageCmd.AddCommand(coreConvertCmd)

--- a/newtmgr/cli/logs.go
+++ b/newtmgr/cli/logs.go
@@ -327,7 +327,7 @@ func logsClearCmd(cmd *cobra.Command, args []string) {
 func logsCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "log",
-		Short: "Handle logs on a device",
+		Short: "Manage logs on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},

--- a/newtmgr/cli/runtest.go
+++ b/newtmgr/cli/runtest.go
@@ -29,7 +29,7 @@ import (
 func runCmd() *cobra.Command {
 	runCmd := &cobra.Command{
 		Use:   "run",
-		Short: "Run procedures on a device",
+		Short: "Run test procedures on a device",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.HelpFunc()(cmd, args)
 		},
@@ -37,9 +37,14 @@ func runCmd() *cobra.Command {
 
 	runtestEx := "  newtmgr -c conn run test all 201612161220"
 
+	runTestHelpText := "Run tests on a device. Specify a testname to run a "
+	runTestHelpText += "specific test. All tests are\nrun if \"all\" or no "
+	runTestHelpText += "testname is specified. If a token-value is "
+	runTestHelpText += "specified, the\nvalue is output on the log messages.\n"
 	runTestCmd := &cobra.Command{
-		Use:     "test [all | testname] [token] -c <conn_profile>",
-		Short:   "Run commands a device - \"token\" output on log messages",
+		Use:     "test [all | testname] [token-value] -c <conn_profile>",
+		Short:   "Run tests on a device",
+		Long:    runTestHelpText,
 		Example: runtestEx,
 		Run:     runTestCmd,
 	}
@@ -47,7 +52,7 @@ func runCmd() *cobra.Command {
 
 	runListCmd := &cobra.Command{
 		Use:   "list -c <conn_profile>",
-		Short: "List registered commands on a device",
+		Short: "List registered tests on a device",
 		Run:   runListCmd,
 	}
 	runCmd.AddCommand(runListCmd)

--- a/newtmgr/cli/stats.go
+++ b/newtmgr/cli/stats.go
@@ -110,15 +110,17 @@ func statsRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func statsCmd() *cobra.Command {
+	statsHelpText := "Read statistics for the specified stats_name from a device"
 	statsCmd := &cobra.Command{
-		Use:   "stat ",
+		Use:   "stat [stats_name] -c <conn_profile>",
 		Short: "Read statistics from a device",
+		Long:  statsHelpText,
 		Run:   statsRunCmd,
 	}
 
 	ListCmd := &cobra.Command{
 		Use:   "list -c <conn_profile>",
-		Short: "Read list of statistics from a device",
+		Short: "Read the list of Stats names from a device",
 		Run:   statsListRunCmd,
 	}
 


### PR DESCRIPTION
1) Updated newtmgr crash Usage text: crash test argument required.
2) Updated datetime.go - Moved datetime format examples from error message
   to Help Text examples.
3) Minor formatting for image.go help text
4) Update newtmgr stat command help text:
    a) added stat_name argument in newtmgr stat usage text
    b) updated list subcommand help text to say list of "Stat names" instead
       "statistics".
5) Added more help text  to newtmgr conn show command.
6) Updated help text for newtmgr log command.