### PR TITLE
Remove trailing slash using pkg commands in the shell

### DIFF
--- a/newt/cli/pkg_cmds.go
+++ b/newt/cli/pkg_cmds.go
@@ -60,7 +60,7 @@ func pkgNewCmd(cmd *cobra.Command, args []string) {
 type dirOperation func(string, string) error
 
 func pkgCopyCmd(cmd *cobra.Command, args []string) {
-	pkgCloneOrMoveCmd(cmd, args, util.CopyDir, "Cloning")
+	pkgCloneOrMoveCmd(cmd, args, util.CopyDir, "Copying")
 }
 
 func pkgMoveCmd(cmd *cobra.Command, args []string) {

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -213,6 +213,9 @@ func GetStringSliceFeatures(v *viper.Viper, features map[string]bool,
 //         string               package name
 //         error                if invalid package string
 func ParsePackageString(pkgStr string) (string, string, error) {
+	// remove possible trailing '/'
+	pkgStr = strings.TrimSuffix(pkgStr, "/")
+
 	if strings.HasPrefix(pkgStr, "@") {
 		nameParts := strings.SplitN(pkgStr[1:], "/", 2)
 		if len(nameParts) == 1 {


### PR DESCRIPTION
Removes the suffix slash when using shell completion like in this example:

`newt pkg copy hw/bsp/stm32f4discovery/ hw/bsp/stm32f7discovery/`

This would create a new pkg with the name `hw/bsp/stm32f7discovery/` which is invalid.