### PR TITLE
Warns on unmatched pkg.name and pkg.path

### DIFF
--- a/newt/interfaces/interfaces.go
+++ b/newt/interfaces/interfaces.go
@@ -22,6 +22,7 @@ package interfaces
 type PackageInterface interface {
 	Name() string
 	FullName() string
+	BasePath() string
 	Repo() RepoInterface
 	Type() PackageType
 }

--- a/newt/pkg/package.go
+++ b/newt/pkg/package.go
@@ -71,6 +71,8 @@ type Package interface {
 	FullName() string
 	// The type of package (lib, target, bsp, etc.)
 	Type() interfaces.PackageType
+	// BasePath is the path on disk if it's a local package
+	BasePath() string
 	// Hash of the contents of the package
 	Hash() (string, error)
 	// Description of this package

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -497,13 +497,40 @@ func (proj *Project) Init(dir string) error {
 	return nil
 }
 
+func matchNamePath(name, path string) bool {
+	// assure that name and path use the same path separator...
+	names := filepath.SplitList(name)
+	name = filepath.Join(names...)
+
+	if strings.HasSuffix(path, name) {
+		return true
+	}
+	return false
+}
+
 func (proj *Project) ResolveDependency(dep interfaces.DependencyInterface) interfaces.PackageInterface {
+	type NamePath struct {
+		name string
+		path string
+	}
+
+	var errorPkgs []NamePath
 	for _, pkgList := range proj.packages {
 		for _, pkg := range *pkgList {
+			name := pkg.Name()
+			path := pkg.BasePath()
+			if !matchNamePath(name, path) {
+				errorPkgs = append(errorPkgs, NamePath{name: name, path: path})
+			}
 			if dep.SatisfiesDependency(pkg) {
 				return pkg
 			}
 		}
+	}
+
+	for _, namepath := range errorPkgs {
+		util.StatusMessage(util.VERBOSITY_VERBOSE,
+			"Package name \"%s\" doesn't match path \"%s\"\n", namepath.name, namepath.path)
 	}
 
 	return nil

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -131,12 +131,12 @@ func NewResolvePkg(lpkg *pkg.LocalPackage) *ResolvePackage {
 	}
 }
 
-func (r *Resolver) resolveDep(dep *pkg.Dependency) (*pkg.LocalPackage, error) {
+func (r *Resolver) resolveDep(dep *pkg.Dependency, depender string) (*pkg.LocalPackage, error) {
 	proj := project.GetProject()
 
 	if proj.ResolveDependency(dep) == nil {
 		return nil, util.FmtNewtError("Could not resolve package dependency: "+
-			"%s; depender: %s", dep.String(), dep.Name)
+			"%s; depender: %s", dep.String(), depender)
 	}
 	lpkg := proj.ResolveDependency(dep).(*pkg.LocalPackage)
 
@@ -284,13 +284,14 @@ func (r *Resolver) loadDepsForPkg(rpkg *ResolvePackage) (bool, error) {
 	changed := false
 	newDeps := newtutil.GetStringSliceFeatures(rpkg.Lpkg.PkgV, features,
 		"pkg.deps")
+	depender := rpkg.Lpkg.Name()
 	for _, newDepStr := range newDeps {
 		newDep, err := pkg.NewDependency(rpkg.Lpkg.Repo(), newDepStr)
 		if err != nil {
 			return false, err
 		}
 
-		lpkg, err := r.resolveDep(newDep)
+		lpkg, err := r.resolveDep(newDep, depender)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This adds a warning (when running in verbose mode) if a pkg.name is not equal to the current pkg path.