### PR TITLE
Support for Windows Path to fix newt test problems

### DIFF
--- a/newt/builder/selftest.go
+++ b/newt/builder/selftest.go
@@ -133,7 +133,8 @@ func (b *Builder) testOwner(bpkg *BuildPackage) *BuildPackage {
 	curPath := bpkg.rpkg.Lpkg.BasePath()
 
 	for {
-		parentPath := filepath.Dir(curPath)
+		parentPath := filepath.ToSlash(filepath.Dir(curPath))
+
 		if parentPath == project.GetProject().BasePath || parentPath == "." {
 			return nil
 		}

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -67,7 +67,7 @@ func testablePkgs() map[*pkg.LocalPackage]struct{} {
 	// Next add first ancestor of each test package.
 	for _, testPkgItf := range testPkgs {
 		testPkg := testPkgItf.(*pkg.LocalPackage)
-		for cur := filepath.Dir(testPkg.BasePath()); cur != proj.BasePath; cur = filepath.Dir(cur) {
+		for cur := filepath.ToSlash(filepath.Dir(testPkg.BasePath())); cur != proj.BasePath; cur = filepath.ToSlash(filepath.Dir(cur)) {
 			lpkg := pathLpkgMap[cur]
 			if lpkg != nil && lpkg.Type() != pkg.PACKAGE_TYPE_UNITTEST {
 				testablePkgMap[lpkg] = struct{}{}
@@ -90,8 +90,9 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 	result := []*pkg.LocalPackage{}
 	srcPath := pack.BasePath()
 	for p, _ := range testablePkgs() {
+		dirPath := filepath.ToSlash(filepath.Dir(p.BasePath()))
 		if p.Type() == pkg.PACKAGE_TYPE_UNITTEST &&
-			filepath.Dir(p.BasePath()) == srcPath {
+			dirPath == srcPath {
 
 			result = append(result, p)
 		}

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -85,6 +85,7 @@ func initProject(dir string) error {
 func initialize() error {
 	if globalProject == nil {
 		wd, err := os.Getwd()
+		wd = filepath.ToSlash(wd)
 		if err != nil {
 			return util.NewNewtError(err.Error())
 		}
@@ -654,7 +655,9 @@ func findProjectDir(dir string) (string, error) {
 
 		// Move back one directory and continue searching
 		dir = path.Clean(dir + "../../")
-		if dir == "/" {
+		// path.Clean returns . if processing results in empty string.
+		// Need to check for . on Windows.
+		if dir == "/" || dir == "." {
 			return "", util.NewNewtError("No project file found!")
 		}
 	}

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -749,6 +749,7 @@ func (c *Compiler) RecursiveCollectEntries(cType int,
 	for _, ext := range exts {
 		files, _ := filepath.Glob(c.srcDir + "/*." + ext)
 		for _, file := range files {
+			file = filepath.ToSlash(file)
 			entries = append(entries, CompilerJob{
 				Filename:     file,
 				Compiler:     c,


### PR DESCRIPTION
 -  Convert paths to slashes for paths returned from `filepath.Dir` and `filepath.Glob` to make `newt test` work correctly.