### PR TITLE
MYNEWT-753 newt - sysinit file inconsistent

### DIFF
--- a/newt/sysinit/sysinit.go
+++ b/newt/sysinit/sysinit.go
@@ -69,9 +69,20 @@ func writePrototypes(pkgs []*pkg.LocalPackage, w io.Writer) {
 }
 
 func writeStage(stage int, initFuncs []*initFunc, w io.Writer) {
-	fmt.Fprintf(w, "    /*** Stage %d */\n", stage)
+	// Sort stage alphabetically by package name.
+	pkgNames := make([]string, len(initFuncs))
+	funcMap := make(map[string]*initFunc, len(initFuncs))
 	for i, initFunc := range initFuncs {
-		fmt.Fprintf(w, "    /* %d.%d: %s */\n", stage, i, initFunc.pkg.Name())
+		name := initFunc.pkg.Name()
+		pkgNames[i] = name
+		funcMap[name] = initFunc
+	}
+	sort.Strings(pkgNames)
+
+	fmt.Fprintf(w, "    /*** Stage %d */\n", stage)
+	for i, pkgName := range pkgNames {
+		initFunc := funcMap[pkgName]
+		fmt.Fprintf(w, "    /* %d.%d: %s */\n", stage, i, pkgName)
 		fmt.Fprintf(w, "    %s();\n", initFunc.name)
 	}
 }


### PR DESCRIPTION
In the generated sysinit C file, calls to initialization functions are
sorted by stage number. Within a stage number, the ordering is random,
and varies from one build to the next. The randomness comes from
Golang's random iteration of maps.

This is bad because it prevents repeatable builds, and causes
unnecessary rebuilds.

The fix is to sort alphabetically by package name within a stage number.

So,
    * First sort by stage number
    * Then sort by package name.