### PR TITLE
Separate syscalls for unix and windows in unixchild.go

### DIFF
--- a/util/unixchild/syscall_unix.go
+++ b/util/unixchild/syscall_unix.go
@@ -1,0 +1,31 @@
+// +build !windows
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package unixchild
+
+import (
+	"syscall"
+)
+
+func SetSysProcAttrSetPGID() *syscall.SysProcAttr {
+
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/util/unixchild/syscall_windows.go
+++ b/util/unixchild/syscall_windows.go
@@ -1,0 +1,33 @@
+// +build windows
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package unixchild
+
+import (
+	"syscall"
+)
+
+func SetSysProcAttrSetPGID() *syscall.SysProcAttr {
+
+	// XXX NOT TESTED
+
+	return &syscall.SysProcAttr{CreationFlags: 0x00000008}
+}

--- a/util/unixchild/unixchild.go
+++ b/util/unixchild/unixchild.go
@@ -29,7 +29,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -108,7 +107,7 @@ func New(conf Config) *Client {
 
 func (c *Client) startChild() (*exec.Cmd, error) {
 	subProcess := exec.Command(c.childPath, c.childArgs...)
-	subProcess.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	subProcess.SysProcAttr = SetSysProcAttrSetPGID()
 
 	stdin, err := subProcess.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
Note that this only fixes build errors on windows.  ble support is not tested on windows.