### PR TITLE
MYNEWT-640 Added newt target amend command.

### DIFF
--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -41,6 +41,10 @@ import (
 )
 
 var targetForce bool = false
+var amendDelete bool = false
+
+// target variables that can have values amended with the amend command.
+var amendVars = []string{"aflags", "cflags", "lflags", "syscfg"}
 
 func resolveExistingTargetArg(arg string) (*target.Target, error) {
 	t := ResolveTarget(arg)
@@ -76,13 +80,89 @@ func targetContainsUserFiles(t *target.Target) (bool, error) {
 func pkgVarSliceString(pack *pkg.LocalPackage, key string) string {
 	features := pack.PkgV.GetStringSlice(key)
 	sort.Strings(features)
-
 	var buffer bytes.Buffer
 	for _, f := range features {
 		buffer.WriteString(f)
 		buffer.WriteString(" ")
 	}
 	return buffer.String()
+}
+
+//Process amend command for syscfg target variable
+func amendSysCfg(value string, t *target.Target) error {
+
+	// Get the current syscfg.vals name-value pairs
+	sysVals := t.Package().SyscfgV.GetStringMapString("syscfg.vals")
+
+	// Convert the input syscfg into name-value pairs
+	amendSysVals, err := syscfg.KeyValueFromStr(value)
+	if err != nil {
+		return err
+	}
+	// Have current syscfg.vals in syscfg.yml file
+	if sysVals != nil {
+		// Either delete syscfg variable or replace with new value
+		for k, v := range amendSysVals {
+			if amendDelete {
+				delete(sysVals, k)
+			} else {
+				sysVals[k] = v
+			}
+		}
+	} else {
+		// No syscfg.vals in syscfg.yml file. Use all the new
+		// syscfg name-value  pairs if not deleting
+		if !amendDelete {
+			sysVals = amendSysVals
+		}
+	}
+	t.Package().SyscfgV.Set("syscfg.vals", sysVals)
+	return nil
+}
+
+//Process amend command for aflags, cflags, and lflags target variables.
+func amendBuildFlags(kv []string, t *target.Target) error {
+	pkg_var := "pkg." + kv[0]
+	curFlags := t.Package().PkgV.GetStringSlice(pkg_var)
+	amendFlags := strings.Fields(kv[1])
+
+	newFlags := []string{}
+	exist := false
+
+	// add flags
+	if !amendDelete {
+		newFlags = curFlags
+		for _, amendVal := range amendFlags {
+			exist = false
+			for _, curVal := range curFlags {
+				if amendVal == curVal {
+					exist = true
+				}
+			}
+			// Add flag if flag is not already set
+			if !exist {
+				newFlags = append(newFlags, amendVal)
+			}
+		}
+	} else {
+		// Delete Flag if it exist.
+		for _, curVal := range curFlags {
+			exist = false
+			for _, deleteVal := range amendFlags {
+				if deleteVal == curVal {
+					exist = true
+					break
+				}
+			}
+			// Not deleting this flag, add it to the set of new
+			// flags to save
+			if !exist {
+				newFlags = append(newFlags, curVal)
+			}
+		}
+	}
+	t.Package().PkgV.Set(pkg_var, newFlags)
+	return nil
 }
 
 func targetShowCmd(cmd *cobra.Command, args []string) {
@@ -226,6 +306,81 @@ func targetSetCmd(cmd *cobra.Command, args []string) {
 				"Target %s successfully set %s to %s\n", t.FullName(), kv[0],
 				kv[1])
 		}
+	}
+}
+
+func targetAmendCmd(cmd *cobra.Command, args []string) {
+	if len(args) < 2 {
+		NewtUsage(cmd,
+			util.NewNewtError("Must specify at least two arguments "+
+				"(target-name & variable=value) to append"))
+	}
+
+	TryGetProject()
+
+	// Parse target name.
+	t, err := resolveExistingTargetArg(args[0])
+	if err != nil {
+		NewtUsage(cmd, err)
+	}
+
+	// Parse series of k=v pairs.  If an argument doesn't contain a '='
+	// character, display the valid values for the variable and quit.
+	vars := [][]string{}
+	for i := 1; i < len(args); i++ {
+		kv := strings.SplitN(args[i], "=", 2)
+		// Check that the variable can have values appended.
+		valid := false
+		for _, v := range amendVars {
+			if kv[0] == v {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			NewtUsage(cmd,
+				util.NewNewtError("Cannot amend values for "+kv[0]))
+		}
+
+		if len(kv) == 1 {
+			// User entered a variable name without a '='
+			NewtUsage(cmd, nil)
+		}
+		kv[1] = strings.TrimSpace(kv[1])
+		if kv[1] == "" {
+			NewtUsage(cmd,
+				util.NewNewtError("Must provide a value to"+
+					" append for variable "+kv[0]))
+
+		}
+		// Trim trailing slash from value.  This is necessary when tab
+		// completion is used to fill in the value.
+		kv[1] = strings.TrimSuffix(kv[1], "/")
+		vars = append(vars, kv)
+	}
+	for _, kv := range vars {
+		if kv[0] == "syscfg" {
+			err = amendSysCfg(kv[1], t)
+			if err != nil {
+				NewtUsage(cmd, err)
+			}
+		} else if kv[0] == "cflags" ||
+			kv[0] == "lflags" ||
+			kv[0] == "aflags" {
+			err = amendBuildFlags(kv, t)
+			if err != nil {
+				NewtUsage(cmd, err)
+			}
+		}
+	}
+	if err := t.Save(); err != nil {
+		NewtUsage(cmd, err)
+	}
+
+	for _, kv := range vars {
+		util.StatusMessage(util.VERBOSITY_DEFAULT,
+			"Amended %s for Target %s successfully\n",
+			kv[0], t.FullName())
 	}
 }
 
@@ -677,6 +832,8 @@ func AddTargetCommands(cmd *cobra.Command) {
 	setHelpText += "Warning: When setting the syscfg variable, a new syscfg.yml file\n"
 	setHelpText += "is created and the current settings are deleted. Only the settings\n"
 	setHelpText += "specified in the command are saved in the syscfg.yml file."
+	setHelpText += "\nIf you want to change or add a new syscfg value and keep the other\n"
+	setHelpText += "syscfg values, use the newt target amend command.\n"
 	setHelpEx := "  newt target set my_target1 build_profile=optimized "
 	setHelpEx += "cflags=\"-DNDEBUG\"\n"
 	setHelpEx += "  newt target set my_target1 "
@@ -684,7 +841,7 @@ func AddTargetCommands(cmd *cobra.Command) {
 
 	setCmd := &cobra.Command{
 		Use: "set <target-name> <var-name>=<value>" +
-			"[:<var-name>=<value>...]",
+			"[<var-name>=<value>...]",
 		Short:   "Set target configuration variable",
 		Long:    setHelpText,
 		Example: setHelpEx,
@@ -692,6 +849,33 @@ func AddTargetCommands(cmd *cobra.Command) {
 	}
 	targetCmd.AddCommand(setCmd)
 	AddTabCompleteFn(setCmd, targetList)
+
+	amendHelpText := "Add, change, or delete values for multi-value target variables\n\n"
+	amendHelpText += "Variables that can have values amended are:\n"
+	amendHelpText += strings.Join(amendVars, "\n") + "\n\n"
+	amendHelpText += "To change the value for a single value variable, such as bsp, use the\nnewt target set command.\n"
+
+	amendHelpEx := "  newt target amend my_target cflags=\"-DNDEBUG -DTEST\"\n"
+	amendHelpEx += "    Adds -DDEBUG and -DTEST to cflags\n\n"
+	amendHelpEx += "  newt target amend my_target lflags=\"-Lmylib\" "
+	amendHelpEx += "syscfg=LOG_LEVEL:CONFIG_NEWTMGR=0\n"
+	amendHelpEx += "    Adds -Lmylib to lflags and syscfg variables LOG_LEVEL=1 and CONFIG_NEWTMGR=0\n\n"
+	amendHelpEx += "  newt target amend my_target -d syscfg=CONFIG_NEWTMGR "
+	amendHelpEx += "cflags=\"-DNDEBUG\"\n"
+	amendHelpEx += "    Deletes syscfg variable CONFIG_NEWTMGR and -DNDEBUG from cflags\n"
+
+	amendCmd := &cobra.Command{
+		Use: "amend <target-name> <var-name>=<value>" +
+			"[<var-name>=<value>...]\n",
+		Short:   "Add, change, or delete values for multi-value target variables",
+		Long:    amendHelpText,
+		Example: amendHelpEx,
+		Run:     targetAmendCmd,
+	}
+	amendCmd.Flags().BoolVarP(&amendDelete, "delete", "d", false,
+		"Delete Variable values")
+	targetCmd.AddCommand(amendCmd)
+	AddTabCompleteFn(amendCmd, targetList)
 
 	createHelpText := "Create a target specified by <target-name>."
 	createHelpEx := "  newt target create <target-name>\n"


### PR DESCRIPTION
The `newt target amend` command allows the user to add, change, delete values
for multi-value target variables without overwriting existing values.  This addresses the concern raised in MYNEWT-543.

The amend command uses the same format as `newt target set`.  The variables that can have values appended are: syscfg, cflags, aflags, and lfags. It supports a -d flag to delete values.