### PR TITLE
image: Add support for RSA-PSS signatures

### DIFF
--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"mynewt.apache.org/newt/newt/builder"
+	"mynewt.apache.org/newt/newt/image"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/util"
 )
@@ -89,6 +90,9 @@ func AddImageCommands(cmd *cobra.Command) {
 	createImageCmd.PersistentFlags().BoolVarP(&newtutil.NewtForce,
 		"force", "f", false,
 		"Ignore flash overflow errors during image creation")
+	createImageCmd.PersistentFlags().BoolVar(&image.UseRsaPss,
+		"rsa-pss", false,
+		"Use RSA-PSS instead of PKCS#1 v1.5 for RSA sigs")
 
 	cmd.AddCommand(createImageCmd)
 	AddTabCompleteFn(createImageCmd, targetList)


### PR DESCRIPTION
Currently, RSA signatures are done with PKCS#1 v1.5.  Newer versions of
this standard (starting with 2.1) define a newer signing algorithm, PSS,
and enourage adoption of this algorithm over the older method.

Add support for this to the 'newt' tool so that create-image can sign
RSA with PSS.  Since the keys are the same, add a command line argument
`--rsa-pss` to use the new algorithm.  Once this is adopted more fully
by the bootloader this could be made the default.