### PR TITLE
Fix building targets which are inside repos defined by project.

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -140,7 +140,7 @@ func buildRunCmd(cmd *cobra.Command, args []string) {
 
 		// Look up the target by name.  This has to be done a second time here
 		// now that the project has been reset.
-		t := ResolveTarget(targets[i].Name())
+		t := ResolveTarget(targets[i].FullName())
 		if t == nil {
 			NewtUsage(nil, util.NewNewtError("Failed to resolve target: "+
 				targets[i].Name()))


### PR DESCRIPTION
This makes it possible for us to build targets which are declared within sub-repositories.
I.e.
newt build @this_is_my_repo/targets/this_is_my_target