### PR TITLE
syscfg - Only apply conditional overrides if condition is true

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -322,8 +322,10 @@ func (cfg *Cfg) readDefsOnce(lpkg *pkg.LocalPackage,
 	v := lpkg.SyscfgV
 
 	lfeatures := cfg.FeaturesForLpkg(lpkg)
-	for k, _ := range features {
-		lfeatures[k] = true
+	for k, v := range features {
+		if v {
+			lfeatures[k] = true
+		}
 	}
 
 	settings := newtutil.GetStringMapFeatures(v, lfeatures, "syscfg.defs")
@@ -360,8 +362,10 @@ func (cfg *Cfg) readValsOnce(lpkg *pkg.LocalPackage,
 	v := lpkg.SyscfgV
 
 	lfeatures := cfg.FeaturesForLpkg(lpkg)
-	for k, _ := range features {
-		lfeatures[k] = true
+	for k, v := range features {
+		if v {
+			lfeatures[k] = true
+		}
 	}
 
 	values := newtutil.GetStringMapFeatures(v, lfeatures, "syscfg.vals")


### PR DESCRIPTION
(Jira: https://issues.apache.org/jira/browse/MYNEWT-791)

This commit fixes a bug involving conditional overrides of syscfg
values.  In the following syscfg listing:

    syscfg.vals.MY_SETTING:
        LOG_LEVEL: 255

LOG_LEVEL should only get set to 255 if MY_SETTING is defined with a
true value (nonzero and non-empty-string).  However, the actual behavior
is that LOG_LEVEL gets overridden if MY_SETTING is defined at all,
regardless of its value.

The fix is to only apply the override if the condition is true.