### PR TITLE
syscfg - Allow a package to override its own setting

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -362,16 +362,16 @@ func (r *Resolver) reloadCfg() (bool, error) {
 		return false, err
 	}
 
-	changed := false
+	// Determine if any settings have changed.
 	for k, v := range cfg.Settings {
 		oldval, ok := r.cfg.Settings[k]
 		if !ok || len(oldval.History) != len(v.History) {
 			r.cfg = cfg
-			changed = true
+			return true, nil
 		}
 	}
 
-	return changed, nil
+	return false, nil
 }
 
 func (r *Resolver) resolveDepsOnce() (bool, error) {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -370,8 +370,10 @@ func (cfg *Cfg) readValsOnce(lpkg *pkg.LocalPackage,
 		if ok {
 			sourcetype := normalizePkgType(lpkg.Type())
 			deftype := normalizePkgType(entry.PackageDef.Type())
-			if sourcetype <= deftype {
-				// Overrides must come from a higher priority package.
+
+			// Overrides must come from a higher priority package, with one
+			// exception: a package can override its own setting.
+			if lpkg != entry.PackageDef && sourcetype <= deftype {
 				priority := CfgPriority{
 					PackageDef:  entry.PackageDef,
 					PackageSrc:  lpkg,


### PR DESCRIPTION
(Jira: https://issues.apache.org/jira/browse/MYNEWT-790)

syscfg - Allow a package to override its own setting.

PKG-A can only override a setting defined by PKG-B if PKG-A has a
greater priority than PKG-B.  If PKG-A's priority is less than or equal
to PKG-B's, the override attempt is rejected and reported as a priority
violation.

This commit relaxes that rule slightly: a package can override settings
that it itself defines.

This behavior is needed  for making a setting's default value
conditional on another setting.  For example:

```
    syscfg.defs:
        TIMER_0:
            description: 'NRF52 Timer 0'
            value:  1
        TIMER_3:
            description: 'NRF52 Timer 3'
            value:  0

    # Use timer 3 instead of timer 0 if target wants to use the low
    # power clock.
    syscfg.vals.BLE_LP_CLOCK:
        TIMER_0: 0
        TIMER_3: 1
```